### PR TITLE
Remodel appending

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,40 +58,61 @@ jobs:
           path: ./llvm
           key: llvm-19.0
 
+      - name: Check for cached LLVM directory and list contents
+        id: check-llvm-dir
+        run: |
+          echo "🔍 Checking for ./llvm directory and its contents..."
+          ls -la ./llvm || echo "  ./llvm directory not found or empty." # List contents, suppress error if not found
+
+          if [ -d "./llvm" ]; then
+            echo "status=found" >> $GITHUB_OUTPUT
+            echo "✅ ./llvm directory found."
+          else
+            echo "status=not-found" >> $GITHUB_OUTPUT
+            echo "❌ ./llvm directory not found."
+          fi
       # Conditionally Install LLVM and Clang ONLY if ./llvm was not found
       - name: Install LLVM and Clang (version 19.1.0)
         # Only run this step if the 'llvm/' directory was not found by the previous step
+        if: steps.check-llvm-dir.outputs.status == 'not-found'
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "19.1.0"
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
-      # This step sets LIBCLANG_PATH and RUSTFLAGS regardless of cache hit/miss
-      - name: Set LIBCLANG_PATH and Linker Flags
+      - name: Set LIBCLANG_PATH and Linker Flags (with Absolute Paths)
         run: |
           echo "🔍 Setting LIBCLANG_PATH and RUSTFLAGS for linker..."
-
+          
           # Determine the LLVM lib directory path
+          LLVM_INSTALL_DIR="" # Initialize to empty
+          
           # Prioritize LLVM_PATH if set (means install-llvm-action ran recently)
           if [ -n "${{ env.LLVM_PATH }}" ]; then
               LLVM_INSTALL_DIR="${{ env.LLVM_PATH }}"
               echo "Using LLVM_PATH from install-llvm-action: ${LLVM_INSTALL_DIR}"
           # Otherwise, assume it was restored from cache in the ./llvm directory
           elif [ -d "./llvm" ]; then
-              LLVM_INSTALL_DIR="./llvm"
-              echo "Using cached LLVM path: ${LLVM_INSTALL_DIR}"
+              # Convert the relative path to an absolute path using 'pwd -P'
+              # GITHUB_WORKSPACE is the absolute path to the repository root
+              LLVM_INSTALL_DIR="${GITHUB_WORKSPACE}/llvm"
+              echo "Using cached LLVM path (absolute): ${LLVM_INSTALL_DIR}"
           else
               echo "❌ Error: LLVM installation directory not found after cache or install step. This job will likely fail."
               echo "LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
-              exit 1 
+              exit 1
           fi
-
+          
+          # Ensure LLVM_INSTALL_DIR is now an absolute path for consistency
+          # (This step is mostly for clarity, as the above logic already ensures it)
+          # If LLVM_PATH was already absolute, it remains so.
+          # If it was ./llvm, it's now converted to absolute.
+          
           LLVM_LIB_DIR="${LLVM_INSTALL_DIR}/lib"
-
+          
           if [ -d "$LLVM_LIB_DIR" ]; then
             echo "LIBCLANG_PATH=$LLVM_LIB_DIR" >> $GITHUB_ENV
             echo "✅ LIBCLANG_PATH set to: $LLVM_LIB_DIR"
-            
+          
             CURRENT_RUSTFLAGS="${{ env.RUSTFLAGS }}"
             if [[ -z "$CURRENT_RUSTFLAGS" ]]; then
               echo "RUSTFLAGS=-L $LLVM_LIB_DIR" >> $GITHUB_ENV
@@ -99,18 +120,18 @@ jobs:
               echo "RUSTFLAGS=$CURRENT_RUSTFLAGS -L $LLVM_LIB_DIR" >> $GITHUB_ENV
             fi
             echo "✅ RUSTFLAGS modified to include -L $LLVM_LIB_DIR"
-            
+          
             echo "🔍 Verification: Listing libclang files in $LLVM_LIB_DIR"
             ls -la "$LLVM_LIB_DIR"/libclang* 2>/dev/null || echo "No libclang.so* files found in $LLVM_LIB_DIR."
           else
             echo "❌ Error: LLVM lib directory ($LLVM_LIB_DIR) not found. This job will likely fail."
+            # Provide a fallback for LIBCLANG_PATH even if the main path isn't found
             echo "LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
-            exit 1 
+            exit 1
           fi
-
-          echo "Final LIBCLANG_PATH: $LIBCLANG_PATH"
-          echo "Final RUSTFLAGS: $RUSTFLAGS"
-
+          
+          echo "Final LIBCLANG_PATH: ${LIBCLANG_PATH:-'Not Set Yet (check logs above for actual value)'}"
+          echo "Final RUSTFLAGS: ${RUSTFLAGS:-'Not Set Yet (check logs above for actual value)'}"
       - name: Clean previous build artifacts (removed `cargo clean`)
         run: ls -lah # Changed from `cargo clean` to just `ls -lah` for debugging
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,35 +43,28 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-            llvm # Path where KyleMayes/install-llvm-action might extract LLVM
+            llvm/ # Path where KyleMayes/install-llvm-action might extract LLVM
           key: ${{ runner.os }}-cargo-llvm-19.1.0-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-llvm-19.1.0-
             ${{ runner.os }}-cargo-
-
+      - run: dir && ls -lah
       # New step: Check if LLVM directory exists after cache restore
       # Explicitly runs ls -la ./llvm and then checks its existence.
-      - name: Check for cached LLVM directory and list contents
-        id: check-llvm-dir
-        run: |
-          echo "🔍 Checking for ./llvm directory and its contents..."
-          ls -la ./llvm || echo "  ./llvm directory not found or empty." # List contents, suppress error if not found
-
-          if [ -d "./llvm" ]; then
-            echo "status=found" >> $GITHUB_OUTPUT
-            echo "✅ ./llvm directory found."
-          else
-            echo "status=not-found" >> $GITHUB_OUTPUT
-            echo "❌ ./llvm directory not found."
-          fi
+      - name: Cache LLVM and Clang build
+        id: cached-llvm
+        uses: actions/cache@v3
+        with:
+          path: ./llvm
+          key: llvm-19.0
 
       # Conditionally Install LLVM and Clang ONLY if ./llvm was not found
       - name: Install LLVM and Clang (version 19.1.0)
         # Only run this step if the 'llvm/' directory was not found by the previous step
-        if: steps.check-llvm-dir.outputs.status == 'not-found'
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "19.1.0"
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       # This step sets LIBCLANG_PATH and RUSTFLAGS regardless of cache hit/miss
       - name: Set LIBCLANG_PATH and Linker Flags

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -63,41 +63,40 @@ jobs:
         with:
           path: ./llvm
           key: llvm-19.0
-
-      # Conditionally Install LLVM and Clang ONLY if ./llvm was not found
-      - name: Install LLVM and Clang (version 19.1.0)
-        # Only run this step if the 'llvm/' directory was not found by the previous step
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "19.1.0"
-      # New step: Check if LLVM directory exists after cache restore
-
-      # This step sets LIBCLANG_PATH and RUSTFLAGS regardless of cache hit/miss
-      - name: Set LIBCLANG_PATH and Linker Flags
+      - name: Set LIBCLANG_PATH and Linker Flags (with Absolute Paths)
         run: |
           echo "🔍 Setting LIBCLANG_PATH and RUSTFLAGS for linker..."
-
+          
           # Determine the LLVM lib directory path
+          LLVM_INSTALL_DIR="" # Initialize to empty
+          
           # Prioritize LLVM_PATH if set (means install-llvm-action ran recently)
           if [ -n "${{ env.LLVM_PATH }}" ]; then
               LLVM_INSTALL_DIR="${{ env.LLVM_PATH }}"
               echo "Using LLVM_PATH from install-llvm-action: ${LLVM_INSTALL_DIR}"
           # Otherwise, assume it was restored from cache in the ./llvm directory
           elif [ -d "./llvm" ]; then
-              LLVM_INSTALL_DIR="./llvm"
-              echo "Using cached LLVM path: ${LLVM_INSTALL_DIR}"
+              # Convert the relative path to an absolute path using 'pwd -P'
+              # GITHUB_WORKSPACE is the absolute path to the repository root
+              LLVM_INSTALL_DIR="${GITHUB_WORKSPACE}/llvm"
+              echo "Using cached LLVM path (absolute): ${LLVM_INSTALL_DIR}"
           else
               echo "❌ Error: LLVM installation directory not found after cache or install step. This job will likely fail."
               echo "LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
-              exit 1 
+              exit 1
           fi
-
+          
+          # Ensure LLVM_INSTALL_DIR is now an absolute path for consistency
+          # (This step is mostly for clarity, as the above logic already ensures it)
+          # If LLVM_PATH was already absolute, it remains so.
+          # If it was ./llvm, it's now converted to absolute.
+          
           LLVM_LIB_DIR="${LLVM_INSTALL_DIR}/lib"
-
+          
           if [ -d "$LLVM_LIB_DIR" ]; then
             echo "LIBCLANG_PATH=$LLVM_LIB_DIR" >> $GITHUB_ENV
             echo "✅ LIBCLANG_PATH set to: $LLVM_LIB_DIR"
-            
+          
             CURRENT_RUSTFLAGS="${{ env.RUSTFLAGS }}"
             if [[ -z "$CURRENT_RUSTFLAGS" ]]; then
               echo "RUSTFLAGS=-L $LLVM_LIB_DIR" >> $GITHUB_ENV
@@ -105,18 +104,18 @@ jobs:
               echo "RUSTFLAGS=$CURRENT_RUSTFLAGS -L $LLVM_LIB_DIR" >> $GITHUB_ENV
             fi
             echo "✅ RUSTFLAGS modified to include -L $LLVM_LIB_DIR"
-            
+          
             echo "🔍 Verification: Listing libclang files in $LLVM_LIB_DIR"
             ls -la "$LLVM_LIB_DIR"/libclang* 2>/dev/null || echo "No libclang.so* files found in $LLVM_LIB_DIR."
           else
             echo "❌ Error: LLVM lib directory ($LLVM_LIB_DIR) not found. This job will likely fail."
+            # Provide a fallback for LIBCLANG_PATH even if the main path isn't found
             echo "LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
-            exit 1 
+            exit 1
           fi
-
-          echo "Final LIBCLANG_PATH: $LIBCLANG_PATH"
-          echo "Final RUSTFLAGS: $RUSTFLAGS"
-
+          
+          echo "Final LIBCLANG_PATH: ${LIBCLANG_PATH:-'Not Set Yet (check logs above for actual value)'}"
+          echo "Final RUSTFLAGS: ${RUSTFLAGS:-'Not Set Yet (check logs above for actual value)'}"
       - name: Run Cargo Bench (with increased memory limits)
         run: |
           ulimit -v unlimited || true

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -50,35 +50,27 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-            llvm # Path where KyleMayes/install-llvm-action might extract LLVM
+            target/
+            llvm/ # Path where KyleMayes/install-llvm-action might extract LLVM
           key: ${{ runner.os }}-cargo-llvm-19.1.0-${{ hashFiles('**/Cargo.lock') }} # Updated LLVM version in key
           restore-keys: |
             ${{ runner.os }}-cargo-llvm-19.1.0-
             ${{ runner.os }}-cargo-
 
-      # New step: Check if LLVM directory exists after cache restore
-      - name: Check for cached LLVM directory and list contents
-        id: check-llvm-dir # Added ID
-        run: |
-          echo "🔍 Checking for ./llvm directory and its contents..."
-          ls -la ./llvm || echo "  ./llvm directory not found or empty." # List contents, suppress error if not found
-
-          if [ -d "./llvm" ]; then
-            echo "status=found" >> $GITHUB_OUTPUT
-            echo "✅ ./llvm directory found."
-          else
-            echo "status=not-found" >> $GITHUB_OUTPUT
-            echo "❌ ./llvm directory not found."
-          fi
+      - name: Cache LLVM and Clang build
+        id: cached-llvm
+        uses: actions/cache@v3
+        with:
+          path: ./llvm
+          key: llvm-19.0
 
       # Conditionally Install LLVM and Clang ONLY if ./llvm was not found
       - name: Install LLVM and Clang (version 19.1.0)
-        # Only run this step if the 'llvm/' directory was not found
-        if: steps.check-llvm-dir.outputs.status == 'not-found'
+        # Only run this step if the 'llvm/' directory was not found by the previous step
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "19.1.0"
+      # New step: Check if LLVM directory exists after cache restore
 
       # This step sets LIBCLANG_PATH and RUSTFLAGS regardless of cache hit/miss
       - name: Set LIBCLANG_PATH and Linker Flags

--- a/src/stores/mod.rs
+++ b/src/stores/mod.rs
@@ -76,7 +76,9 @@ impl NodeStore for TreeCache {
             .map(|index| self.get_index(index).map(|(key, _)| *key))?
     }
     fn sort(&mut self) {
-        self.sort_unstable_by(|_, node1, _, node2| node1.data.cmp(&node2.data));
+        self.sort_unstable_by(|path, node1, path2, node2| {
+            node1.data.cmp(&node2.data).then_with(|| path.cmp(path2))
+        });
     }
     fn entries(&self) -> impl Iterator<Item = (PathTrace, Node)> {
         self.iter().map(|(k, v)| (*k, *v))

--- a/src/stores/sled_storage.rs
+++ b/src/stores/sled_storage.rs
@@ -1,6 +1,6 @@
 use super::NodeStore;
-use crate::PathTrace;
 use crate::Node;
+use crate::PathTrace;
 use sled::{Batch, Db, Result};
 use sled::{IVec, Tree};
 #[derive(Clone, Debug)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -108,7 +108,7 @@ impl PathTrace {
             return None;
         }
         if self.level == lowest_level + 1 {
-            return Some(Self::new(HashDirection::Center, 0, 0));
+            return Some(Self::new(HashDirection::Center, lowest_level, 0));
         }
         let level = self.level.saturating_sub(1);
         // we since we know the index of the child (item in the chunk)
@@ -250,9 +250,10 @@ mod path_trace {
     #[test]
     fn generating_routes() {
         let pt = PathTrace::new(HashDirection::Left, 3, 4);
-        let lowest_level = 0;
+        let lowest_level = -1;
         let route: Vec<_> = pt.generate_route(lowest_level).collect();
-        assert_eq!(route.len(), 4);
+        dbg!(&route);
+        assert_eq!(route.len(), 5);
         assert_eq!(route[0].level, 3);
         assert_eq!(route[1].level, 2);
         assert_eq!(route[2].level, 1);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -72,10 +72,10 @@ pub struct Proof {
     /// The hashes to use when verifying the proof
     /// The first element of the tuple is which side the hash should be on when concatinating
     /// Add level to the proof eases visualization of the proof
-    pub hashes: Vec<(usize, HashDirection, Hash)>, // (level, direction, hash)
+    pub hashes: Vec<(isize, HashDirection, Hash)>, // (level, direction, hash)
 }
 impl Proof {
-    pub fn get_proof_in_hex(&self) -> Vec<(usize, HashDirection, String)> {
+    pub fn get_proof_in_hex(&self) -> Vec<(isize, HashDirection, String)> {
         self.hashes
             .iter()
             .map(|(level, direction, hash)| (*level, *direction, hex::encode(hash)))
@@ -85,39 +85,42 @@ impl Proof {
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, std::hash::Hash, Serialize, Deserialize)]
 pub struct PathTrace {
-    pub level: usize,
+    pub level: isize,
     pub direction: HashDirection,
     pub index: usize,
 }
 impl PathTrace {
-    pub fn root() -> Self {
-        Self::default()
+    pub fn root(lowest_level: isize) -> Self {
+        Self {
+            level: lowest_level,
+            ..Default::default()
+        }
     }
-    pub fn new(direction: HashDirection, level: usize, index: usize) -> Self {
+    pub fn new(direction: HashDirection, level: isize, index: usize) -> Self {
         Self {
             level,
             direction,
             index,
         }
     }
-    pub fn get_parent_path(&self) -> Option<Self> {
-        match self.level {
-            0 => None,
-            1 => Some(Self::new(HashDirection::Center, 0, 0)),
-            _ => {
-                let level = self.level.saturating_sub(1);
-                // we since we know the index of the child (item in the chunk)
-                // parent_index =  child_index / chunkSize, we use only chunk of two
-                // each level,  we have 2.pow(level) chunks, so root level 2^^0 = 1 chunk;
-                let parent_index = self.index / 2;
-                let direction = HashDirection::from_index(parent_index);
-                Some(Self {
-                    level,
-                    direction,
-                    index: parent_index,
-                })
-            }
+    pub fn get_parent_path(&self, lowest_level: isize) -> Option<Self> {
+        if self.level == lowest_level {
+            return None;
         }
+        if self.level == lowest_level + 1 {
+            return Some(Self::new(HashDirection::Center, 0, 0));
+        }
+        let level = self.level.saturating_sub(1);
+        // we since we know the index of the child (item in the chunk)
+        // parent_index =  child_index / chunkSize, we use only chunk of two
+        // each level,  we have 2.pow(level) chunks, so root level 2^^0 = 1 chunk;
+        let parent_index = self.index / 2;
+        let direction = HashDirection::from_index(parent_index);
+        Some(Self {
+            level,
+            direction,
+            index: parent_index,
+        })
     }
     pub fn get_sibling_path(&self) -> Self {
         let next_index = self.direction.next_node_index(self.index);
@@ -127,11 +130,13 @@ impl PathTrace {
             ..*self
         }
     }
-    pub fn generate_route(&self) -> impl Iterator<Item = Self> {
+    pub fn generate_route(&self, lowest_level: isize) -> impl Iterator<Item = Self> {
         // only generate the path on demand
         use std::iter::successors;
         // To get the route, just work out the parent at level
-        successors(Some(*self), |current| current.get_parent_path())
+        successors(Some(*self), move |current| {
+            current.get_parent_path(lowest_level)
+        })
     }
 }
 impl Ord for PathTrace {
@@ -158,11 +163,11 @@ pub fn hash_data<T: AsRef<[u8]>>(data: &T) -> Hash {
 pub fn hash_concat<T: AsRef<[u8]>>(h1: &T, h2: &T) -> Hash {
     hash_data(&[h1.as_ref(), h2.as_ref()].concat())
 }
-pub fn get_level_count(leaf_count: usize) -> usize {
+pub fn get_level_count(leaf_count: usize) -> isize {
     if leaf_count == 0 {
         return 0;
     }
-    ((leaf_count as f64).log2().ceil()) as usize
+    ((leaf_count as f64).log2().ceil()) as isize
 }
 
 pub fn example_data(n: usize) -> Vec<Data> {
@@ -173,8 +178,8 @@ pub fn example_data(n: usize) -> Vec<Data> {
     data
 }
 
-pub fn max_index_at_level_reversed(leaf_count: usize, depth: usize, level: usize) -> usize {
-    let shift = depth - 1 - level;
+pub fn max_index_at_level_reversed(leaf_count: usize, depth: isize, level: isize) -> usize {
+    let shift = (depth - 1 - level) as usize;
     let nodes = (leaf_count + (1 << shift) - 1) >> shift; // ceil division
     nodes.saturating_sub(1)
 }
@@ -211,19 +216,20 @@ mod path_trace {
     #[test]
     fn getting_parent_paths() {
         let pt = PathTrace::new(HashDirection::Left, 3, 4);
-        let parent = pt.get_parent_path().unwrap();
+        let lowest_level = 0;
+        let parent = pt.get_parent_path(lowest_level).unwrap();
         assert_eq!(parent.level, 2);
         assert_eq!(parent.index, 2);
         assert_eq!(parent.direction, HashDirection::Left);
 
         let pt2 = PathTrace::new(HashDirection::Left, 1, 0);
-        let parent2 = pt2.get_parent_path().unwrap();
+        let parent2 = pt2.get_parent_path(lowest_level).unwrap();
         assert_eq!(parent2.level, 0);
         assert_eq!(parent2.direction, HashDirection::Center);
         assert_eq!(parent2.index, 0);
 
         let pt3 = PathTrace::new(HashDirection::Left, 0, 0);
-        assert!(pt3.get_parent_path().is_none());
+        assert!(pt3.get_parent_path(lowest_level).is_none());
     }
 
     #[test]
@@ -244,7 +250,8 @@ mod path_trace {
     #[test]
     fn generating_routes() {
         let pt = PathTrace::new(HashDirection::Left, 3, 4);
-        let route: Vec<_> = pt.generate_route().collect();
+        let lowest_level = 0;
+        let route: Vec<_> = pt.generate_route(lowest_level).collect();
         assert_eq!(route.len(), 4);
         assert_eq!(route[0].level, 3);
         assert_eq!(route[1].level, 2);

--- a/src/utils/tree_construction.rs
+++ b/src/utils/tree_construction.rs
@@ -57,7 +57,7 @@ fn build_sequential<S: NodeStore + Send>(
                 direction = HashDirection::Center;
             }
             // when rebuild, move increase the level-count
-            if level == lowest_level + 1 && is_rebuild {
+            if level == lowest_level && is_rebuild {
                 direction = HashDirection::Right;
                 parent_index = 1;
             }
@@ -106,14 +106,15 @@ fn build_parallel(
 
     let parent_hash = hash_concat(&left_node.data, &right_node.data);
     let parent_level_in_tree = left_path.level - 1;
-    let parent_index = left_path.index / 2;
+    let mut parent_index = left_path.index / 2;
 
     let mut direction = HashDirection::from_index(parent_index);
     if parent_level_in_tree == lowest_level {
         direction = HashDirection::Center;
     }
-    if parent_level_in_tree == lowest_level + 1 && is_rebuild {
+    if parent_level_in_tree == lowest_level && is_rebuild {
         direction = HashDirection::Right;
+        parent_index = 1
     }
 
     let parent_node = Node {

--- a/src/utils/tree_construction.rs
+++ b/src/utils/tree_construction.rs
@@ -1,10 +1,10 @@
-use super::{hash_concat, max_index_at_level_reversed, HashDirection, Node, NodeStore, PathTrace};
+use super::{hash_concat, HashDirection, Node, NodeStore, PathTrace};
 use crossbeam_queue::SegQueue;
 pub fn build_tree<S: NodeStore + Send>(
     tree_cache: &mut S,
     input: impl IntoIterator<Item = Node>,
-    items_index_per_level: &mut [usize],
-    level_count: usize,
+    level_count: isize,
+    lowest_level: isize,
     is_rebuild: bool,
     last_index: usize,
 ) -> (PathTrace, Node) {
@@ -19,15 +19,10 @@ pub fn build_tree<S: NodeStore + Send>(
             (path, data)
         })
         .collect();
-    let leaf_count = if is_rebuild {
-        last_index + nodes.len()
-    } else {
-        nodes.len()
-    };
     let parallelize = level_count > 14;
     if parallelize {
         let generated: SegQueue<(PathTrace, Node)> = SegQueue::new();
-        let result = build_parallel(&nodes, is_rebuild, &generated);
+        let result = build_parallel(&nodes, &generated, lowest_level, is_rebuild);
         drop(nodes);
         for (path, node) in generated {
             tree_cache.set(path, node);
@@ -37,22 +32,13 @@ pub fn build_tree<S: NodeStore + Send>(
         return result;
     }
 
-    build_sequential(
-        tree_cache,
-        nodes,
-        items_index_per_level,
-        level_count,
-        leaf_count,
-        is_rebuild,
-    )
+    build_sequential(tree_cache, nodes, lowest_level, is_rebuild)
 }
 // build the tree  sequentiallly
 fn build_sequential<S: NodeStore + Send>(
     tree_cache: &mut S,
     mut nodes: Vec<(PathTrace, Node)>,
-    items_index_per_level: &mut [usize],
-    level_count: usize,
-    leaf_count: usize,
+    lowest_level: isize,
     is_rebuild: bool,
 ) -> (PathTrace, Node) {
     while nodes.len() > 1 {
@@ -64,17 +50,16 @@ fn build_sequential<S: NodeStore + Send>(
 
             let level = left.level - 1;
 
-            let max_index = max_index_at_level_reversed(leaf_count, level_count, level);
-            let parent_index = items_index_per_level.get_mut(level).unwrap();
-            let mut direction = HashDirection::from_index(*parent_index);
+            let mut parent_index = left.index / 2;
+            let mut direction = HashDirection::from_index(parent_index);
             // when we get the root node
-            if level == 0 {
+            if level == lowest_level {
                 direction = HashDirection::Center;
             }
             // when rebuild, move increase the level-count
-            if level == 1 && is_rebuild {
+            if level == lowest_level + 1 && is_rebuild {
                 direction = HashDirection::Right;
-                *parent_index = 1;
+                parent_index = 1;
             }
 
             let parent_node = Node {
@@ -82,11 +67,10 @@ fn build_sequential<S: NodeStore + Send>(
                 is_leaf: false,
                 from_duplicate: node.from_duplicate,
             };
-            let parent = PathTrace::new(direction, level, *parent_index);
+            let parent = PathTrace::new(direction, level, parent_index);
             tree_cache.set(left, node);
             tree_cache.set(right, right_node);
             tree_cache.set(parent, parent_node);
-            *parent_index = std::cmp::min(*parent_index + 1, max_index);
             next_level.push((parent, parent_node));
         }
         nodes = next_level;
@@ -98,8 +82,9 @@ fn build_sequential<S: NodeStore + Send>(
 /// build the tree in parallel using divide and conquer
 fn build_parallel(
     nodes: &[(PathTrace, Node)],
-    is_rebuild: bool,
     output_buffer: &SegQueue<(PathTrace, Node)>,
+    lowest_level: isize,
+    is_rebuild: bool,
 ) -> (PathTrace, Node) {
     if nodes.len() == 1 {
         if let Some(last) = nodes.last() {
@@ -112,8 +97,8 @@ fn build_parallel(
     let (left_slice, right_slice) = nodes.split_at(mid);
 
     let (left_result, right_result) = rayon::join(
-        || build_parallel(left_slice, is_rebuild, output_buffer),
-        || build_parallel(right_slice, is_rebuild, output_buffer),
+        || build_parallel(left_slice, output_buffer, lowest_level, is_rebuild),
+        || build_parallel(right_slice, output_buffer, lowest_level, is_rebuild),
     );
 
     let (left_path, left_node) = left_result;
@@ -124,10 +109,10 @@ fn build_parallel(
     let parent_index = left_path.index / 2;
 
     let mut direction = HashDirection::from_index(parent_index);
-    if parent_level_in_tree == 0 {
+    if parent_level_in_tree == lowest_level {
         direction = HashDirection::Center;
     }
-    if parent_level_in_tree == 1 && is_rebuild {
+    if parent_level_in_tree == lowest_level + 1 && is_rebuild {
         direction = HashDirection::Right;
     }
 


### PR DESCRIPTION
### Performance improvement
The lowest (root) level shouldn't be permanently set to zero. This allows us to decrement it and only append the next root to the bottom while adding the remaining leaves to the right of the previous tree.
### Problem Statement
 Previously, appending to an unpadded tree required shifting all the current nodes down by a level, which is quite expensive as the node stores are essentially like hashmaps. We'd need to modify the keys by deleting and re-inserting the data without the modified keys.   With that in mind, we have to loop through the entire snapshot ( O(n))  and build a tree of the same size as the tree expands twice.

### Resulting 
It takes the overall time complexity of expanding the tree only one  O(n) to build the right tree with the items and n-copies required to get the next nearest power of two, and an O(1) operation to update the direction and index of the current root.